### PR TITLE
Add Polling Override preprocessor command

### DIFF
--- a/hiduniversal.cpp
+++ b/hiduniversal.cpp
@@ -332,6 +332,10 @@ void HIDUniversal::EndpointXtract(uint8_t conf, uint8_t iface, uint8_t alt, uint
                 if(pollInterval < pep->bInterval) // Set the polling interval as the largest polling interval obtained from endpoints
                         pollInterval = pep->bInterval;
 
+#ifdef POLLING_OVERRIDE
+                pollInterval = POLLING_OVERRIDE;
+#endif
+
                 bNumEP++;
         }
         //PrintEndpointDescriptor(pep);


### PR DESCRIPTION
This adds an optional Preprocessor command to override the usb polling speed to what ever value you want.  This needs to go before any include statements in a file.

Usage:
`#define POLLING_OVERRIDE <value>`
for example if you want it to be 1000 you would use:
`#define POLLING_OVERRIDE 1000`